### PR TITLE
feat(sites): add site configuration registry

### DIFF
--- a/md_fetch/sites/__init__.py
+++ b/md_fetch/sites/__init__.py
@@ -1,0 +1,54 @@
+"""Site configuration registry for md_fetch."""
+
+from __future__ import annotations
+
+from fnmatch import fnmatch
+from urllib.parse import urlparse
+
+from md_fetch.sites.base import SiteConfig
+
+__all__ = ["SiteConfig", "SiteRegistry", "UnsupportedSiteError"]
+
+
+class UnsupportedSiteError(Exception):
+    """Raised when no registered SiteConfig matches the given URL."""
+
+
+class SiteRegistry:
+    """Registry that maps URLs to their SiteConfig by hostname pattern."""
+
+    def __init__(self) -> None:
+        self._configs: list[SiteConfig] = []
+
+    def register(self, config: SiteConfig) -> None:
+        """Register a site configuration."""
+        self._configs.append(config)
+
+    def find(self, url: str) -> SiteConfig:
+        """Find the matching SiteConfig for a URL.
+
+        Args:
+            url: The URL to look up.
+
+        Returns:
+            The first matching SiteConfig.
+
+        Raises:
+            ValueError: If *url* is empty or has no extractable hostname.
+            UnsupportedSiteError: If no registered config matches.
+        """
+        if not url:
+            raise ValueError("url must not be empty")
+
+        host = urlparse(url).hostname
+        if not host:
+            raise ValueError(f"Could not extract hostname from url: {url!r}")
+
+        for config in self._configs:
+            for pattern in config.host_patterns:
+                if fnmatch(host, pattern):
+                    return config
+
+        raise UnsupportedSiteError(
+            f"No site configuration found for host {host!r}"
+        )

--- a/md_fetch/sites/base.py
+++ b/md_fetch/sites/base.py
@@ -1,0 +1,29 @@
+"""Base class for site-specific content extraction configuration."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class SiteConfig(ABC):
+    """Abstract base class defining the extraction contract for a single site."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str: ...
+
+    @property
+    @abstractmethod
+    def host_patterns(self) -> list[str]: ...
+
+    @property
+    @abstractmethod
+    def content_selector(self) -> str: ...
+
+    @property
+    @abstractmethod
+    def title_selector(self) -> str: ...
+
+    @property
+    @abstractmethod
+    def remove_selectors(self) -> list[str]: ...

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -1,0 +1,123 @@
+"""Tests for site configuration registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from md_fetch.sites import SiteConfig, SiteRegistry, UnsupportedSiteError
+
+
+class _DummySiteConfig(SiteConfig):
+    """Concrete SiteConfig for testing."""
+
+    @property
+    def name(self) -> str:
+        return "dummy"
+
+    @property
+    def host_patterns(self) -> list[str]:
+        return ["note.com", "*.note.com"]
+
+    @property
+    def content_selector(self) -> str:
+        return "article"
+
+    @property
+    def title_selector(self) -> str:
+        return "h1"
+
+    @property
+    def remove_selectors(self) -> list[str]:
+        return [".ads", ".sidebar"]
+
+
+class _AnotherDummySiteConfig(SiteConfig):
+    """Second concrete SiteConfig for priority testing."""
+
+    @property
+    def name(self) -> str:
+        return "another"
+
+    @property
+    def host_patterns(self) -> list[str]:
+        return ["*.note.com"]
+
+    @property
+    def content_selector(self) -> str:
+        return "main"
+
+    @property
+    def title_selector(self) -> str:
+        return "h2"
+
+    @property
+    def remove_selectors(self) -> list[str]:
+        return []
+
+
+@pytest.fixture()
+def registry() -> SiteRegistry:
+    reg = SiteRegistry()
+    reg.register(_DummySiteConfig())
+    return reg
+
+
+class TestSiteRegistryNormal:
+    """Normal: register + find."""
+
+    def test_find_exact_host(self, registry: SiteRegistry) -> None:
+        config = registry.find("https://note.com/article/123")
+        assert config.name == "dummy"
+
+    def test_find_returns_site_config_instance(self, registry: SiteRegistry) -> None:
+        config = registry.find("https://note.com/")
+        assert isinstance(config, SiteConfig)
+
+    def test_register_multiple_configs(self, registry: SiteRegistry) -> None:
+        registry.register(_AnotherDummySiteConfig())
+        # Both registered, first match wins for exact host
+        config = registry.find("https://note.com/")
+        assert config.name == "dummy"
+
+
+class TestSiteRegistryError:
+    """Error: expected exceptions."""
+
+    def test_unsupported_site(self, registry: SiteRegistry) -> None:
+        with pytest.raises(UnsupportedSiteError, match="example.com"):
+            registry.find("https://example.com/page")
+
+    def test_empty_url(self, registry: SiteRegistry) -> None:
+        with pytest.raises(ValueError, match="must not be empty"):
+            registry.find("")
+
+    def test_no_hostname(self, registry: SiteRegistry) -> None:
+        with pytest.raises(ValueError, match="Could not extract hostname"):
+            registry.find("not-a-url")
+
+
+class TestSiteRegistryBoundary:
+    """Boundary: edge-case URLs."""
+
+    def test_subdomain_wildcard(self, registry: SiteRegistry) -> None:
+        config = registry.find("https://www.note.com/article")
+        assert config.name == "dummy"
+
+    def test_url_with_path_and_query(self, registry: SiteRegistry) -> None:
+        config = registry.find("https://note.com/path?q=1&r=2#frag")
+        assert config.name == "dummy"
+
+    def test_url_with_port(self, registry: SiteRegistry) -> None:
+        config = registry.find("https://note.com:8080/page")
+        assert config.name == "dummy"
+
+    def test_first_registered_wins(self, registry: SiteRegistry) -> None:
+        """When multiple configs match, the first registered config wins."""
+        registry.register(_AnotherDummySiteConfig())
+        # "www.note.com" matches both _DummySiteConfig and _AnotherDummySiteConfig
+        config = registry.find("https://www.note.com/")
+        assert config.name == "dummy"
+
+    def test_abc_cannot_be_instantiated(self) -> None:
+        with pytest.raises(TypeError):
+            SiteConfig()  # type: ignore[abstract]


### PR DESCRIPTION
## Summary

サイトごとの記事本文セレクタやメタデータ抽出ルールを定義する拡張可能なサイト設定レジストリを実装。`md_fetch/sites/` サブパッケージを新設し、`SiteConfig` ABC + `SiteRegistry` + `UnsupportedSiteError` を追加。新サイト対応は `SiteConfig` サブクラスを1つ追加するだけで完了する設計。

Closes #4

## File Context

### Files changed

**`md_fetch/sites/base.py`** (new file)
- No external imports beyond `abc` (stdlib)
- Defines `SiteConfig` ABC with 5 abstract properties

**`md_fetch/sites/__init__.py`** (new file)
- Stdlib imports: `fnmatch.fnmatch`, `urllib.parse.urlparse`
- Internal import: `md_fetch.sites.base.SiteConfig`
- Defines `SiteRegistry` class and `UnsupportedSiteError` exception

**`tests/test_sites.py`** (new file)
- Imports: `pytest`, `md_fetch.sites.SiteConfig`, `md_fetch.sites.SiteRegistry`, `md_fetch.sites.UnsupportedSiteError`
- Test doubles: `_DummySiteConfig`, `_AnotherDummySiteConfig` (concrete SiteConfig implementations)

## Goal / Non-Goals

**Goal:**
- サイト設定の抽象基底クラス (`SiteConfig` ABC) を定義し、サブクラスに実装を強制
- `fnmatch` ベースのホスト名マッチングで URL → SiteConfig を解決する `SiteRegistry` を実装
- Normal / Error / Boundary の3カテゴリで11テストを実装

**Non-Goals:**
- 具体的なサイト設定（note.com, zenn.dev 等）の実装は別 issue で対応
- `fetcher.py` との統合（fetch → セレクタ適用 → Markdown 変換）は別 issue で対応
- グローバルレジストリやシングルトンパターンの導入

## Data Model

N/A: DB やデータストアへのアクセスなし。全てインメモリのクラスインスタンス。

## Existing Safety Mechanisms

N/A: 新規サブパッケージのため既存の安全機構はなし。

## Code Patterns

- 例外は raise するモジュールに定義（`fetcher.py` の `FetchError` と同パターン）
- docstring スタイルは `fetcher.py` に準拠（Google style）
- `from __future__ import annotations` を全モジュールで使用
- ABC + `@property` + `@abstractmethod` でサブクラスに実装を強制

## Accepted Risks

- **`fnmatch` のパターン制約**: 複雑な正規表現パターンは表現できない
  - Reason: サイトのホスト名マッチングには `fnmatch` で十分。正規表現は認知負荷が高く過剰
  - Fallback: 将来的に正規表現が必要になった場合、`host_patterns` の型を拡張可能

## Test Plan

- [x] `SiteRegistry.find` が完全一致ホストで正しい `SiteConfig` を返す
- [x] `SiteRegistry.find` の戻り値が `SiteConfig` インスタンスである
- [x] 複数 config 登録時に先勝ちで解決される
- [x] 未登録サイトで `UnsupportedSiteError` が発生する
- [x] 空 URL で `ValueError` が発生する
- [x] ホスト名抽出不可の URL で `ValueError` が発生する
- [x] サブドメイン (`www.note.com`) がワイルドカードでマッチする
- [x] パス・クエリ・フラグメント付き URL が正しくマッチする
- [x] ポート付き URL (`note.com:8080`) が正しくマッチする
- [x] 複数 config が同パターンにマッチする場合、先に登録された方が返る
- [x] `SiteConfig()` の直接インスタンス化が `TypeError` になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)