### PR TITLE
feat(converter): add HTML-to-Markdown conversion module

### DIFF
--- a/md_fetch/converter.py
+++ b/md_fetch/converter.py
@@ -1,0 +1,89 @@
+"""Convert HTML to Markdown using site-specific extraction rules."""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+
+import markdownify
+from bs4 import BeautifulSoup, Tag
+
+from md_fetch.sites.base import SiteConfig
+
+
+class ConversionError(Exception):
+    """Raised when HTML cannot be converted to Markdown."""
+
+
+@dataclasses.dataclass(frozen=True)
+class ConvertResult:
+    """Result of converting HTML to Markdown."""
+
+    title: str
+    markdown: str
+
+
+def _detect_language(el: Tag) -> str | None:
+    """Extract language name from a ``<pre>`` element's child ``<code>`` class.
+
+    Called by markdownify with the ``<pre>`` element.  Looks for a child
+    ``<code>`` whose class matches ``language-xxx`` or ``lang-xxx`` patterns
+    commonly used by syntax highlighters (Prism, Highlight.js, etc.).
+    """
+    code = el.find("code") if el.name == "pre" else el
+    if code is None:
+        return None
+    classes = code.get("class") or []
+    for cls in classes:
+        match = re.match(r"(?:language|lang)-(\w+)", cls)
+        if match:
+            return match.group(1)
+    return None
+
+
+def convert_to_markdown(html: str, site_config: SiteConfig) -> ConvertResult:
+    """Convert an HTML string to Markdown based on a site configuration.
+
+    Args:
+        html: Raw HTML string.
+        site_config: Site-specific extraction rules.
+
+    Returns:
+        A ConvertResult with title and markdown body.
+
+    Raises:
+        ConversionError: If *html* is empty or the content selector matches nothing.
+    """
+    if not html or not html.strip():
+        raise ConversionError("HTML must not be empty")
+
+    soup = BeautifulSoup(html, "html.parser")
+
+    # Extract content element
+    content = soup.select_one(site_config.content_selector)
+    if content is None:
+        raise ConversionError(
+            f"No element matched content_selector {site_config.content_selector!r}"
+        )
+
+    # Remove unwanted elements
+    for selector in site_config.remove_selectors:
+        for el in content.select(selector):
+            el.decompose()
+
+    # Extract title
+    title_el = soup.select_one(site_config.title_selector)
+    title = title_el.get_text(strip=True) if title_el else ""
+
+    # Convert to Markdown
+    md = markdownify.markdownify(
+        str(content),
+        heading_style="ATX",
+        code_language_callback=_detect_language,
+    )
+
+    # Collapse 3+ consecutive blank lines into 2
+    md = re.sub(r"\n{3,}", "\n\n", md)
+    md = md.strip()
+
+    return ConvertResult(title=title, markdown=md)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,0 +1,203 @@
+"""Tests for HTML-to-Markdown converter."""
+
+from __future__ import annotations
+
+import pytest
+
+from md_fetch.converter import ConversionError, ConvertResult, convert_to_markdown
+from md_fetch.sites.base import SiteConfig
+
+
+class _DummySiteConfig(SiteConfig):
+    """Concrete SiteConfig for converter tests."""
+
+    @property
+    def name(self) -> str:
+        return "dummy"
+
+    @property
+    def host_patterns(self) -> list[str]:
+        return ["example.com"]
+
+    @property
+    def content_selector(self) -> str:
+        return "article"
+
+    @property
+    def title_selector(self) -> str:
+        return "h1"
+
+    @property
+    def remove_selectors(self) -> list[str]:
+        return [".ads", "nav"]
+
+
+_CFG = _DummySiteConfig()
+
+
+class TestConvertNormal:
+    """Normal: successful conversions."""
+
+    def test_basic_paragraph(self) -> None:
+        html = "<h1>Title</h1><article><p>Hello world</p></article>"
+        result = convert_to_markdown(html, _CFG)
+        assert isinstance(result, ConvertResult)
+        assert result.title == "Title"
+        assert "Hello world" in result.markdown
+
+    def test_heading_atx_style(self) -> None:
+        html = "<h1>Title</h1><article><h2>Sub</h2><p>body</p></article>"
+        result = convert_to_markdown(html, _CFG)
+        assert "## Sub" in result.markdown
+
+    def test_code_block_with_language(self) -> None:
+        html = (
+            "<h1>Title</h1>"
+            "<article>"
+            '<pre><code class="language-python">print("hi")</code></pre>'
+            "</article>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert "```python" in result.markdown
+        assert 'print("hi")' in result.markdown
+
+    def test_code_block_lang_prefix(self) -> None:
+        html = (
+            "<h1>Title</h1>"
+            "<article>"
+            '<pre><code class="lang-js">const x = 1;</code></pre>'
+            "</article>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert "```js" in result.markdown
+
+    def test_image_conversion(self) -> None:
+        html = (
+            "<h1>Title</h1>"
+            '<article><img src="pic.png" alt="photo"></article>'
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert "![photo](pic.png)" in result.markdown
+
+    def test_title_extraction(self) -> None:
+        html = "<h1> My  Title </h1><article><p>body</p></article>"
+        result = convert_to_markdown(html, _CFG)
+        assert result.title == "My  Title"
+
+    def test_missing_title_element(self) -> None:
+        html = "<article><p>No title here</p></article>"
+        result = convert_to_markdown(html, _CFG)
+        assert result.title == ""
+        assert "No title here" in result.markdown
+
+    def test_link_conversion(self) -> None:
+        html = '<h1>T</h1><article><a href="https://example.com">link</a></article>'
+        result = convert_to_markdown(html, _CFG)
+        assert "[link](https://example.com)" in result.markdown
+
+
+class TestConvertError:
+    """Error: expected exceptions."""
+
+    def test_empty_html(self) -> None:
+        with pytest.raises(ConversionError, match="empty"):
+            convert_to_markdown("", _CFG)
+
+    def test_whitespace_only_html(self) -> None:
+        with pytest.raises(ConversionError, match="empty"):
+            convert_to_markdown("   \n  ", _CFG)
+
+    def test_content_selector_no_match(self) -> None:
+        html = "<h1>Title</h1><div><p>Not an article</p></div>"
+        with pytest.raises(ConversionError, match="content_selector"):
+            convert_to_markdown(html, _CFG)
+
+
+class TestConvertBoundary:
+    """Boundary: edge cases and remove_selectors."""
+
+    def test_remove_selectors_strips_ads(self) -> None:
+        html = (
+            "<h1>Title</h1>"
+            "<article>"
+            "<p>keep</p>"
+            '<div class="ads">remove me</div>'
+            "</article>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert "keep" in result.markdown
+        assert "remove me" not in result.markdown
+
+    def test_remove_selectors_strips_nav(self) -> None:
+        html = (
+            "<h1>Title</h1>"
+            "<article>"
+            "<nav><a>menu</a></nav>"
+            "<p>content</p>"
+            "</article>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert "menu" not in result.markdown
+        assert "content" in result.markdown
+
+    def test_nested_structure(self) -> None:
+        html = (
+            "<h1>Title</h1>"
+            "<article>"
+            "<div><div><p>deep</p></div></div>"
+            "</article>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert "deep" in result.markdown
+
+    def test_special_characters_preserved(self) -> None:
+        html = "<h1>Title</h1><article><p>&amp; &lt; &gt; &quot;</p></article>"
+        result = convert_to_markdown(html, _CFG)
+        assert "&" in result.markdown
+        assert "<" in result.markdown
+        assert ">" in result.markdown
+
+    def test_excessive_blank_lines_collapsed(self) -> None:
+        html = (
+            "<h1>Title</h1>"
+            "<article>"
+            "<p>a</p><br><br><br><br><br><p>b</p>"
+            "</article>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        # Should not have 3+ consecutive newlines
+        assert "\n\n\n" not in result.markdown
+
+    def test_result_is_stripped(self) -> None:
+        html = "<h1>Title</h1><article><p>text</p></article>"
+        result = convert_to_markdown(html, _CFG)
+        assert result.markdown == result.markdown.strip()
+
+    def test_no_remove_selectors(self) -> None:
+        """SiteConfig with empty remove_selectors works fine."""
+
+        class _NoRemoveConfig(SiteConfig):
+            @property
+            def name(self) -> str:
+                return "no-remove"
+
+            @property
+            def host_patterns(self) -> list[str]:
+                return ["example.com"]
+
+            @property
+            def content_selector(self) -> str:
+                return "main"
+
+            @property
+            def title_selector(self) -> str:
+                return "h1"
+
+            @property
+            def remove_selectors(self) -> list[str]:
+                return []
+
+        html = '<h1>Title</h1><main><p>body</p><div class="ads">ad</div></main>'
+        result = convert_to_markdown(html, _NoRemoveConfig())
+        assert "body" in result.markdown
+        assert "ad" in result.markdown


### PR DESCRIPTION
## Summary
SiteConfig のセレクタに基づき HTML から本文抽出・不要要素除去・Markdown 変換を行う `convert_to_markdown()` 関数を実装。
`ConvertResult` dataclass と `ConversionError` 例外を定義し、コードブロック言語の自動検出にも対応。

Closes #5

## File Context

### Files changed

**`md_fetch/converter.py`** (新規)
- Imports: `dataclasses`, `re`, `markdownify`, `bs4.BeautifulSoup`, `bs4.Tag`
- Depends on: `md_fetch.sites.base.SiteConfig` (ABC with `content_selector`, `title_selector`, `remove_selectors` properties)

**`tests/test_converter.py`** (新規)
- Imports: `pytest`, `md_fetch.converter.{ConversionError, ConvertResult, convert_to_markdown}`, `md_fetch.sites.base.SiteConfig`
- Defines `_DummySiteConfig` (concrete SiteConfig for testing, following pattern from `tests/test_sites.py`)

## Goal / Non-Goals

**Goal:**
- HTML 文字列を SiteConfig ルールに基づいて Markdown に変換する公開関数を提供
- `<code>` の `language-xxx` / `lang-xxx` クラスからコードブロック言語を自動検出
- 3行以上の連続空行を2行に整形

**Non-Goals:**
- fetcher.py との統合（別 Issue で対応）
- 具体的なサイト設定の追加（SiteConfig 実装は別スコープ）
- CLI からの呼び出し対応

## Data Model

N/A: DB やデータストアへのアクセスなし。入力は HTML 文字列、出力は `ConvertResult(title: str, markdown: str)` dataclass。

## Existing Safety Mechanisms

- **SiteConfig ABC**: 型安全なセレクタ定義を強制（`content_selector`, `title_selector`, `remove_selectors` は抽象プロパティ）
- **BeautifulSoup html.parser**: 不正な HTML に対しても安全にパース（例外を投げない）

## Code Patterns

- 例外クラスはモジュールレベルで定義（`fetcher.py` の `FetchError` パターンに準拠）
- dataclass は `frozen=True` で不変
- テストは `TestXxxNormal` / `TestXxxError` / `TestXxxBoundary` のクラスベース構成（`test_sites.py` パターンに準拠）
- テスト用の `_DummySiteConfig` はテストファイル内に定義

## Accepted Risks

- **markdownify の変換品質**: 複雑な HTML テーブルやネスト構造で完全な変換を保証しない
  - Reason: markdownify は広く使われるライブラリであり、大半のケースで十分
  - Fallback: サイト固有の問題は SiteConfig の `remove_selectors` で対処可能

## Test Plan

- [x] 基本変換（段落、見出し ATX スタイル、画像、リンク）
- [x] コードブロック言語検出（`language-python`, `lang-js`）
- [x] タイトル抽出（正常系・要素なし時の空文字列）
- [x] エラー系（空 HTML、空白のみ HTML、content_selector 不一致）
- [x] 境界系（remove_selectors 除去、ネスト構造、特殊文字、空行整形、strip）
- [x] 既存テスト（test_sites.py）への影響なし — 29 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)