### PR TITLE
feat(sites): add note.com site configuration

### DIFF
--- a/md_fetch/sites/__init__.py
+++ b/md_fetch/sites/__init__.py
@@ -7,7 +7,7 @@ from urllib.parse import urlparse
 
 from md_fetch.sites.base import SiteConfig
 
-__all__ = ["SiteConfig", "SiteRegistry", "UnsupportedSiteError"]
+__all__ = ["SiteConfig", "SiteRegistry", "UnsupportedSiteError", "create_default_registry"]
 
 
 class UnsupportedSiteError(Exception):
@@ -52,3 +52,12 @@ class SiteRegistry:
         raise UnsupportedSiteError(
             f"No site configuration found for host {host!r}"
         )
+
+
+def create_default_registry() -> SiteRegistry:
+    """Create a SiteRegistry pre-loaded with all built-in site configurations."""
+    from md_fetch.sites.note import NoteSiteConfig
+
+    registry = SiteRegistry()
+    registry.register(NoteSiteConfig())
+    return registry

--- a/md_fetch/sites/note.py
+++ b/md_fetch/sites/note.py
@@ -1,0 +1,33 @@
+"""Site configuration for note.com."""
+
+from __future__ import annotations
+
+from md_fetch.sites.base import SiteConfig
+
+
+class NoteSiteConfig(SiteConfig):
+    """Extraction configuration for note.com articles."""
+
+    @property
+    def name(self) -> str:
+        return "note"
+
+    @property
+    def host_patterns(self) -> list[str]:
+        return ["note.com", "*.note.com"]
+
+    @property
+    def content_selector(self) -> str:
+        return ".note-common-styles__textnote-body"
+
+    @property
+    def title_selector(self) -> str:
+        return ".o-noteContentHeader__title, h1"
+
+    @property
+    def remove_selectors(self) -> list[str]:
+        return [
+            ".o-noteContentHeader__supplement",
+            ".o-noteContentFooter",
+            ".embed-card",
+        ]

--- a/tests/test_note_site.py
+++ b/tests/test_note_site.py
@@ -1,0 +1,148 @@
+"""Tests for note.com site configuration."""
+
+from __future__ import annotations
+
+import pytest
+
+from md_fetch.converter import convert_to_markdown
+from md_fetch.sites import create_default_registry
+from md_fetch.sites.note import NoteSiteConfig
+
+
+_CFG = NoteSiteConfig()
+
+
+class TestNoteSiteConfigProperties:
+    """Verify property values of NoteSiteConfig."""
+
+    def test_name(self) -> None:
+        assert _CFG.name == "note"
+
+    def test_host_patterns(self) -> None:
+        assert _CFG.host_patterns == ["note.com", "*.note.com"]
+
+    def test_content_selector(self) -> None:
+        assert _CFG.content_selector == ".note-common-styles__textnote-body"
+
+    def test_title_selector(self) -> None:
+        assert _CFG.title_selector == ".o-noteContentHeader__title, h1"
+
+    def test_remove_selectors(self) -> None:
+        assert _CFG.remove_selectors == [
+            ".o-noteContentHeader__supplement",
+            ".o-noteContentFooter",
+            ".embed-card",
+        ]
+
+
+class TestNoteSiteConversion:
+    """Integration tests: note.com HTML -> Markdown conversion."""
+
+    def test_title_from_note_header(self) -> None:
+        html = (
+            '<div class="o-noteContentHeader__title">My Note Title</div>'
+            '<div class="note-common-styles__textnote-body">'
+            "<p>Hello note</p>"
+            "</div>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert result.title == "My Note Title"
+        assert "Hello note" in result.markdown
+
+    def test_title_fallback_to_h1(self) -> None:
+        html = (
+            "<h1>Fallback Title</h1>"
+            '<div class="note-common-styles__textnote-body">'
+            "<p>content</p>"
+            "</div>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert result.title == "Fallback Title"
+
+    def test_missing_title(self) -> None:
+        html = (
+            '<div class="note-common-styles__textnote-body">'
+            "<p>no title</p>"
+            "</div>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert result.title == ""
+        assert "no title" in result.markdown
+
+    def test_remove_supplement(self) -> None:
+        html = (
+            '<div class="note-common-styles__textnote-body">'
+            "<p>keep</p>"
+            '<div class="o-noteContentHeader__supplement">date info</div>'
+            "</div>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert "keep" in result.markdown
+        assert "date info" not in result.markdown
+
+    def test_remove_footer(self) -> None:
+        html = (
+            '<div class="note-common-styles__textnote-body">'
+            "<p>body</p>"
+            '<div class="o-noteContentFooter">footer stuff</div>'
+            "</div>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert "body" in result.markdown
+        assert "footer stuff" not in result.markdown
+
+    def test_remove_embed_card(self) -> None:
+        html = (
+            '<div class="note-common-styles__textnote-body">'
+            "<p>text</p>"
+            '<div class="embed-card">embedded</div>'
+            "</div>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert "text" in result.markdown
+        assert "embedded" not in result.markdown
+
+    def test_full_note_article(self) -> None:
+        """Realistic note.com page structure."""
+        html = (
+            '<div class="o-noteContentHeader__title">My Article</div>'
+            '<div class="o-noteContentHeader__supplement">2024-01-01</div>'
+            '<div class="note-common-styles__textnote-body">'
+            "<h2>Section 1</h2>"
+            "<p>First paragraph.</p>"
+            '<div class="embed-card">external link</div>'
+            "<h2>Section 2</h2>"
+            "<p>Second paragraph.</p>"
+            '<div class="o-noteContentFooter">likes and shares</div>'
+            "</div>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert result.title == "My Article"
+        assert "## Section 1" in result.markdown
+        assert "First paragraph." in result.markdown
+        assert "## Section 2" in result.markdown
+        assert "Second paragraph." in result.markdown
+        # Removed elements
+        assert "external link" not in result.markdown
+        assert "likes and shares" not in result.markdown
+
+
+class TestDefaultRegistry:
+    """Tests for create_default_registry()."""
+
+    def test_note_url_matches(self) -> None:
+        registry = create_default_registry()
+        config = registry.find("https://note.com/user/n/abc123")
+        assert config.name == "note"
+
+    def test_note_subdomain_matches(self) -> None:
+        registry = create_default_registry()
+        config = registry.find("https://www.note.com/article")
+        assert config.name == "note"
+
+    def test_unknown_site_raises(self) -> None:
+        from md_fetch.sites import UnsupportedSiteError
+
+        registry = create_default_registry()
+        with pytest.raises(UnsupportedSiteError):
+            registry.find("https://example.com/page")


### PR DESCRIPTION
## Summary

Add `NoteSiteConfig` for note.com article page extraction — the first production `SiteConfig` implementation.
Also add `create_default_registry()` factory function to provide a pre-loaded `SiteRegistry` with all built-in site configs.

Closes #6

## File Context

### Files changed

**`md_fetch/sites/note.py`** (new)
- Imports: `SiteConfig` from `md_fetch.sites.base` (ABC defined in base.py)
- Implements all 5 abstract properties: `name`, `host_patterns`, `content_selector`, `title_selector`, `remove_selectors`

**`md_fetch/sites/__init__.py`** (modified)
- Module-level imports (already present, NOT in diff): `fnmatch`, `urlparse`, `SiteConfig` (L1-L8)
- Classes defined in file (NOT in diff): `UnsupportedSiteError` (L13), `SiteRegistry` (L17) with `register()` and `find()` methods
- Added: `create_default_registry()` function at module level, lazy-imports `NoteSiteConfig`
- Updated: `__all__` to include `create_default_registry`

**`tests/test_note_site.py`** (new)
- Imports: `convert_to_markdown` from `md_fetch.converter`, `create_default_registry` from `md_fetch.sites`, `NoteSiteConfig` from `md_fetch.sites.note`
- Module-level: `_CFG = NoteSiteConfig()` shared test fixture

## Goal / Non-Goals

**Goal:**
- Implement note.com site configuration with CSS selectors for content extraction, title extraction, and noise removal
- Provide `create_default_registry()` as the entry point for consumers to get a registry with all built-in sites

**Non-Goals:**
- CLI integration (will be done in a separate PR)
- Fetcher/converter changes (not needed — existing ABC contract is sufficient)
- Dynamic site config loading or plugin system

## Data Model

N/A: No database or persistent storage involved. Pure in-memory configuration objects.

## Existing Safety Mechanisms

- **SiteConfig ABC contract**: `base.py` enforces all 5 abstract properties via `@abstractmethod` — any incomplete implementation raises `TypeError` at instantiation
- **SiteRegistry.find() validation**: Raises `ValueError` for empty/invalid URLs, `UnsupportedSiteError` for unmatched hosts
- **converter.py content_selector guard**: Raises `ConversionError` if `content_selector` matches nothing in the HTML

## Code Patterns

- Site configs are pure property-based classes inheriting from `SiteConfig` ABC (no `__init__` args)
- `host_patterns` uses fnmatch glob syntax (`*.note.com` for subdomains)
- `title_selector` supports CSS selector groups (comma-separated) — BeautifulSoup `select_one()` returns first match in DOM order
- Lazy imports inside factory functions to avoid circular imports and reduce startup cost
- Tests follow 3-class structure: Properties / Conversion integration / Registry integration

## Accepted Risks

- **CSS selectors may break if note.com redesigns**: Selectors like `.note-common-styles__textnote-body` are tied to note.com's current DOM structure.
  - Reason: This is inherent to any scraping-based approach; no stable API is available
  - Fallback: Update selectors in `NoteSiteConfig` when breakage is detected

## Test Plan

- [x] `TestNoteSiteConfigProperties` (5 tests) — all property values match expected selectors
- [x] `TestNoteSiteConversion` (7 tests) — title extraction (primary selector, h1 fallback, missing), remove_selectors strip supplement/footer/embed-card, full realistic article structure
- [x] `TestDefaultRegistry` (3 tests) — URL match for note.com and subdomain, UnsupportedSiteError for unknown host
- [x] No regressions in existing `test_converter.py` (18 tests) and `test_sites.py` (8 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)