### PR TITLE
feat(cli): integrate URL-to-Markdown pipeline in CLI entry point

### DIFF
--- a/md_fetch/cli.py
+++ b/md_fetch/cli.py
@@ -1,15 +1,157 @@
 """CLI entry point for gh-md-fetch."""
 
+from __future__ import annotations
+
+import argparse
+import re
 import sys
+import unicodedata
+from datetime import date
+from pathlib import Path
+
+from md_fetch.converter import ConversionError, convert_to_markdown
+from md_fetch.fetcher import FetchError, fetch_page
+from md_fetch.sites import UnsupportedSiteError, create_default_registry
+
+_DEFAULT_OUTPUT_DIR = Path.home() / "Downloads"
 
 
-def main():
-    if len(sys.argv) < 2:
-        print("Usage: gh md-fetch <url>", file=sys.stderr)
-        sys.exit(1)
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments.
 
-    print("gh-md-fetch is ready")
+    Args:
+        argv: Argument list (defaults to sys.argv[1:]).
+
+    Returns:
+        Parsed namespace with ``url`` and ``output`` attributes.
+    """
+    parser = argparse.ArgumentParser(
+        prog="gh md-fetch",
+        description="Fetch a web article and convert it to Markdown.",
+    )
+    parser.add_argument("url", help="URL of the article to fetch")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=_DEFAULT_OUTPUT_DIR,
+        help=f"Output directory (default: {_DEFAULT_OUTPUT_DIR})",
+    )
+    return parser.parse_args(argv)
 
 
-if __name__ == "__main__":
-    main()
+def slugify(title: str, *, max_length: int = 80) -> str:
+    """Convert a title into a filesystem-safe slug.
+
+    Keeps CJK and alphanumeric characters, replaces unsafe chars with hyphens.
+    Uses NFKC normalization. Returns "untitled" for empty input.
+
+    Args:
+        title: The article title.
+        max_length: Maximum slug length.
+
+    Returns:
+        A filesystem-safe slug string.
+    """
+    if not title or not title.strip():
+        return "untitled"
+
+    # NFKC normalization (e.g. full-width -> half-width)
+    text = unicodedata.normalize("NFKC", title.strip())
+
+    # Replace any character that is not word-char or CJK with hyphen
+    # \w covers [a-zA-Z0-9_] + Unicode letters/digits
+    text = re.sub(r"[^\w\s-]", "", text)
+    text = re.sub(r"[\s_]+", "-", text)
+    text = re.sub(r"-{2,}", "-", text)
+    text = text.strip("-")
+
+    if not text:
+        return "untitled"
+
+    return text[:max_length].rstrip("-")
+
+
+def _build_filename(title: str) -> str:
+    """Build a dated filename from a title.
+
+    Format: ``YYYY-MM-DD-<slug>.md``
+    """
+    slug = slugify(title)
+    return f"{date.today().isoformat()}-{slug}.md"
+
+
+def save_markdown(content: str, output_dir: Path, filename: str) -> Path:
+    """Save Markdown content to a file.
+
+    If a file with the same name exists, appends a numeric suffix (-1, -2, ...).
+
+    Args:
+        content: Markdown text to write.
+        output_dir: Directory to save into (must exist).
+        filename: Base filename.
+
+    Returns:
+        The path of the saved file.
+
+    Raises:
+        OSError: If *output_dir* does not exist.
+    """
+    if not output_dir.is_dir():
+        raise OSError(f"Output directory does not exist: {output_dir}")
+
+    stem = Path(filename).stem
+    suffix = Path(filename).suffix or ".md"
+
+    path = output_dir / filename
+    counter = 1
+    while path.exists():
+        path = output_dir / f"{stem}-{counter}{suffix}"
+        counter += 1
+
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _run(argv: list[str] | None = None) -> int:
+    """Run the URL-to-Markdown pipeline.
+
+    Returns:
+        Exit code: 0 on success, 1 on error.
+    """
+    args = parse_args(argv)
+
+    registry = create_default_registry()
+    try:
+        site_config = registry.find(args.url)
+    except (UnsupportedSiteError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        html = fetch_page(args.url)
+    except FetchError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        result = convert_to_markdown(html, site_config)
+    except ConversionError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    filename = _build_filename(result.title)
+
+    try:
+        saved = save_markdown(result.markdown, args.output, filename)
+    except OSError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    print(saved)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> None:
+    """CLI entry point. Parses args, runs pipeline, and exits."""
+    sys.exit(_run(argv))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,265 @@
+"""Tests for CLI entry point."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from md_fetch.cli import (
+    _build_filename,
+    _run,
+    parse_args,
+    save_markdown,
+    slugify,
+)
+from md_fetch.converter import ConversionError, ConvertResult
+from md_fetch.fetcher import FetchError, FetchTimeoutError
+from md_fetch.sites import UnsupportedSiteError
+
+
+# ---------------------------------------------------------------------------
+# parse_args
+# ---------------------------------------------------------------------------
+
+
+class TestParseArgsNormal:
+    """Normal: argument parsing."""
+
+    def test_url_only(self) -> None:
+        args = parse_args(["https://note.com/article/123"])
+        assert args.url == "https://note.com/article/123"
+
+    def test_default_output_dir(self) -> None:
+        args = parse_args(["https://note.com/article/123"])
+        assert args.output == Path.home() / "Downloads"
+
+    def test_output_flag_short(self, tmp_path: Path) -> None:
+        args = parse_args(["https://note.com/a", "-o", str(tmp_path)])
+        assert args.output == tmp_path
+
+    def test_output_flag_long(self, tmp_path: Path) -> None:
+        args = parse_args(["https://note.com/a", "--output", str(tmp_path)])
+        assert args.output == tmp_path
+
+
+class TestParseArgsError:
+    """Error: missing required arguments."""
+
+    def test_no_arguments(self) -> None:
+        with pytest.raises(SystemExit) as exc_info:
+            parse_args([])
+        assert exc_info.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# slugify
+# ---------------------------------------------------------------------------
+
+
+class TestSlugifyNormal:
+    """Normal: slug generation."""
+
+    def test_ascii_title(self) -> None:
+        assert slugify("Hello World") == "Hello-World"
+
+    def test_japanese_title(self) -> None:
+        result = slugify("日本語タイトル")
+        assert result == "日本語タイトル"
+
+    def test_mixed_title(self) -> None:
+        result = slugify("Pythonで学ぶ機械学習")
+        assert result == "Pythonで学ぶ機械学習"
+
+    def test_special_characters_removed(self) -> None:
+        result = slugify("Hello! @World# $Test%")
+        assert result == "Hello-World-Test"
+
+    def test_multiple_spaces_collapsed(self) -> None:
+        assert slugify("Hello   World") == "Hello-World"
+
+
+class TestSlugifyBoundary:
+    """Boundary: edge cases for slugify."""
+
+    def test_empty_string(self) -> None:
+        assert slugify("") == "untitled"
+
+    def test_whitespace_only(self) -> None:
+        assert slugify("   ") == "untitled"
+
+    def test_only_special_chars(self) -> None:
+        assert slugify("!@#$%^&*()") == "untitled"
+
+    def test_max_length_truncation(self) -> None:
+        long_title = "a" * 100
+        result = slugify(long_title, max_length=80)
+        assert len(result) <= 80
+
+    def test_max_length_short(self) -> None:
+        result = slugify("Hello World", max_length=5)
+        assert len(result) <= 5
+
+    def test_trailing_hyphen_after_truncation(self) -> None:
+        # "abcde-fgh" truncated to 6 -> "abcde-" -> should strip trailing hyphen
+        result = slugify("abcde fgh", max_length=6)
+        assert not result.endswith("-")
+
+    def test_fullwidth_normalization(self) -> None:
+        # Full-width "Ａ" should normalize to "A"
+        result = slugify("\uff21\uff22\uff23")
+        assert result == "ABC"
+
+
+# ---------------------------------------------------------------------------
+# _build_filename
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFilename:
+    """Normal: dated filename generation."""
+
+    @patch("md_fetch.cli.date")
+    def test_basic_filename(self, mock_date: object) -> None:
+        mock_date.today.return_value = date(2025, 1, 15)  # type: ignore[attr-defined]
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)  # type: ignore[attr-defined]
+        result = _build_filename("My Article")
+        assert result == "2025-01-15-My-Article.md"
+
+    @patch("md_fetch.cli.date")
+    def test_empty_title(self, mock_date: object) -> None:
+        mock_date.today.return_value = date(2025, 1, 15)  # type: ignore[attr-defined]
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)  # type: ignore[attr-defined]
+        result = _build_filename("")
+        assert result == "2025-01-15-untitled.md"
+
+    @patch("md_fetch.cli.date")
+    def test_japanese_title(self, mock_date: object) -> None:
+        mock_date.today.return_value = date(2025, 3, 20)  # type: ignore[attr-defined]
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)  # type: ignore[attr-defined]
+        result = _build_filename("日本語の記事")
+        assert result == "2025-03-20-日本語の記事.md"
+
+
+# ---------------------------------------------------------------------------
+# save_markdown
+# ---------------------------------------------------------------------------
+
+
+class TestSaveMarkdownNormal:
+    """Normal: file saving."""
+
+    def test_save_creates_file(self, tmp_path: Path) -> None:
+        saved = save_markdown("# Hello", tmp_path, "test.md")
+        assert saved.exists()
+        assert saved.read_text(encoding="utf-8") == "# Hello"
+
+    def test_save_returns_correct_path(self, tmp_path: Path) -> None:
+        saved = save_markdown("content", tmp_path, "output.md")
+        assert saved == tmp_path / "output.md"
+
+
+class TestSaveMarkdownError:
+    """Error: expected exceptions."""
+
+    def test_nonexistent_directory(self, tmp_path: Path) -> None:
+        bad_dir = tmp_path / "nonexistent"
+        with pytest.raises(OSError, match="does not exist"):
+            save_markdown("content", bad_dir, "test.md")
+
+
+class TestSaveMarkdownBoundary:
+    """Boundary: duplicate filename handling."""
+
+    def test_duplicate_filename_gets_suffix(self, tmp_path: Path) -> None:
+        (tmp_path / "test.md").write_text("first")
+        saved = save_markdown("second", tmp_path, "test.md")
+        assert saved == tmp_path / "test-1.md"
+        assert saved.read_text(encoding="utf-8") == "second"
+
+    def test_multiple_duplicates(self, tmp_path: Path) -> None:
+        (tmp_path / "test.md").write_text("first")
+        (tmp_path / "test-1.md").write_text("second")
+        saved = save_markdown("third", tmp_path, "test.md")
+        assert saved == tmp_path / "test-2.md"
+
+    def test_empty_content(self, tmp_path: Path) -> None:
+        saved = save_markdown("", tmp_path, "empty.md")
+        assert saved.exists()
+        assert saved.read_text(encoding="utf-8") == ""
+
+
+# ---------------------------------------------------------------------------
+# _run (integration)
+# ---------------------------------------------------------------------------
+
+_DUMMY_HTML = "<h1>Title</h1><article><p>Hello world</p></article>"
+_DUMMY_RESULT = ConvertResult(title="Title", markdown="# Title\n\nHello world")
+
+
+class TestRunNormal:
+    """Normal: successful pipeline execution."""
+
+    @patch("md_fetch.cli.fetch_page", return_value=_DUMMY_HTML)
+    @patch("md_fetch.cli.convert_to_markdown", return_value=_DUMMY_RESULT)
+    @patch("md_fetch.cli.date")
+    def test_success_returns_zero(
+        self, mock_date: object, _mock_convert: object, _mock_fetch: object, tmp_path: Path
+    ) -> None:
+        mock_date.today.return_value = date(2025, 1, 1)  # type: ignore[attr-defined]
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)  # type: ignore[attr-defined]
+        code = _run(["https://note.com/article/1", "-o", str(tmp_path)])
+        assert code == 0
+
+    @patch("md_fetch.cli.fetch_page", return_value=_DUMMY_HTML)
+    @patch("md_fetch.cli.convert_to_markdown", return_value=_DUMMY_RESULT)
+    @patch("md_fetch.cli.date")
+    def test_creates_output_file(
+        self, mock_date: object, _mock_convert: object, _mock_fetch: object, tmp_path: Path
+    ) -> None:
+        mock_date.today.return_value = date(2025, 1, 1)  # type: ignore[attr-defined]
+        mock_date.side_effect = lambda *a, **kw: date(*a, **kw)  # type: ignore[attr-defined]
+        _run(["https://note.com/article/1", "-o", str(tmp_path)])
+        files = list(tmp_path.glob("*.md"))
+        assert len(files) == 1
+        assert files[0].read_text(encoding="utf-8") == _DUMMY_RESULT.markdown
+
+
+class TestRunError:
+    """Error: pipeline failure cases."""
+
+    def test_unsupported_site(self, tmp_path: Path) -> None:
+        code = _run(["https://unsupported.example.com/page", "-o", str(tmp_path)])
+        assert code == 1
+
+    @patch("md_fetch.cli.fetch_page", side_effect=FetchError("connection failed"))
+    def test_fetch_error(self, _mock_fetch: object, tmp_path: Path) -> None:
+        code = _run(["https://note.com/article/1", "-o", str(tmp_path)])
+        assert code == 1
+
+    @patch("md_fetch.cli.fetch_page", side_effect=FetchTimeoutError("timeout"))
+    def test_fetch_timeout(self, _mock_fetch: object, tmp_path: Path) -> None:
+        code = _run(["https://note.com/article/1", "-o", str(tmp_path)])
+        assert code == 1
+
+    @patch("md_fetch.cli.fetch_page", return_value=_DUMMY_HTML)
+    @patch(
+        "md_fetch.cli.convert_to_markdown",
+        side_effect=ConversionError("no content found"),
+    )
+    def test_conversion_error(
+        self, _mock_convert: object, _mock_fetch: object, tmp_path: Path
+    ) -> None:
+        code = _run(["https://note.com/article/1", "-o", str(tmp_path)])
+        assert code == 1
+
+    @patch("md_fetch.cli.fetch_page", return_value=_DUMMY_HTML)
+    @patch("md_fetch.cli.convert_to_markdown", return_value=_DUMMY_RESULT)
+    def test_output_dir_not_exists(
+        self, _mock_convert: object, _mock_fetch: object, tmp_path: Path
+    ) -> None:
+        bad_dir = tmp_path / "nonexistent"
+        code = _run(["https://note.com/article/1", "-o", str(bad_dir)])
+        assert code == 1


### PR DESCRIPTION
## Summary

CLI エントリポイント (cli.py) を拡張し、URL to HTML取得 to MD変換 to ファイル保存の完全パイプラインを統合。
parse_args, slugify, _build_filename, save_markdown, _run, main の6関数を実装。
33件のテストを追加（全77テスト合格）。

Closes #7

## File Context

### Files changed

**md_fetch/cli.py**
- Module-level imports (already present, NOT in diff): import sys (L3)
- Module-level imports (added in diff): argparse, re, unicodedata, date, Path (standard library), ConversionError/convert_to_markdown from md_fetch.converter, FetchError/fetch_page from md_fetch.fetcher, UnsupportedSiteError/create_default_registry from md_fetch.sites
- Module-level constants: _DEFAULT_OUTPUT_DIR = Path.home() / Downloads (L16)
- Functions defined: parse_args (L19), slugify (L42), _build_filename (L73), save_markdown (L81), _run (L108), main (L139)

**tests/test_cli.py** (new file)
- Test classes: TestParseArgs(Normal,Error), TestSlugify(Normal,Boundary), TestSaveMarkdown(Normal,Error,Boundary), TestBuildFilename, TestRun(Normal,Error)
- Uses unittest.mock.patch for fetch_page, convert_to_markdown, date

## Goal / Non-Goals

**Goal:**
- URL to Markdown 変換パイプラインを CLI から実行可能にする
- 日本語タイトルを保持した slug 生成（python-slugify 不使用）
- 重複ファイル名の連番付与（-1, -2, ...）
- 構造化エラーハンドリング（各ステップで catch して stderr + exit 1）

**Non-Goals:**
- 複数 URL の一括処理
- 設定ファイル対応
- verbose / quiet フラグ
- カスタム出力フォーマット（Markdown 以外）

## Data Model

N/A: CLI ツールであり、DB 操作は行わない。入出力はファイルシステムのみ。

## Existing Safety Mechanisms

- **argparse のバリデーション**: URL 引数なしで exit code 2 を返す（argparse 標準動作）
- **SiteRegistry.find()**: 未対応サイトで UnsupportedSiteError を raise
- **save_markdown のディレクトリ検証**: output_dir.is_dir() で存在チェック、不在なら OSError
- **ファイル重複回避**: while path.exists() ループで連番付与、既存ファイルを上書きしない

## Code Patterns

- エラーハンドリング: 各ステップで個別の例外型を catch し stderr に出力 + return 1
- テスト構造: Normal/Error/Boundary クラス構成（既存テストと統一）
- _run() がテスタブルな内部関数、main() は sys.exit(_run()) のみ
- 標準ライブラリのみ使用（外部依存追加なし）

## Accepted Risks

- **slugify の CJK 文字保持**: ファイルシステムによっては CJK 文字を含むファイル名が問題になる可能性
  - Reason: macOS/Linux では問題なし、Windows の一部レガシーシステムのみリスク
  - Fallback: --output フラグで ASCII-safe なディレクトリを指定可能

## Test Plan

- [x] pytest tests/test_cli.py -v -- 33 passed
- [x] pytest tests/ -v -- 全 77 テスト passed
- [x] 実環境での md-fetch (note.com URL) 動作確認