### PR TITLE
feat(sites): add Qiita site support

### DIFF
--- a/md_fetch/sites/__init__.py
+++ b/md_fetch/sites/__init__.py
@@ -57,7 +57,9 @@ class SiteRegistry:
 def create_default_registry() -> SiteRegistry:
     """Create a SiteRegistry pre-loaded with all built-in site configurations."""
     from md_fetch.sites.note import NoteSiteConfig
+    from md_fetch.sites.qiita import QiitaSiteConfig
 
     registry = SiteRegistry()
     registry.register(NoteSiteConfig())
+    registry.register(QiitaSiteConfig())
     return registry

--- a/md_fetch/sites/qiita.py
+++ b/md_fetch/sites/qiita.py
@@ -1,0 +1,33 @@
+"""Site configuration for qiita.com."""
+
+from __future__ import annotations
+
+from md_fetch.sites.base import SiteConfig
+
+
+class QiitaSiteConfig(SiteConfig):
+    """Extraction configuration for qiita.com articles."""
+
+    @property
+    def name(self) -> str:
+        return "qiita"
+
+    @property
+    def host_patterns(self) -> list[str]:
+        return ["qiita.com", "*.qiita.com"]
+
+    @property
+    def content_selector(self) -> str:
+        return ".it-MdContent, .s-MdContent"
+
+    @property
+    def title_selector(self) -> str:
+        return "h1.it-Header_title, .it-MdContent h1:first-child, article h1"
+
+    @property
+    def remove_selectors(self) -> list[str]:
+        return [
+            ".it-MdContent__tableOfContents",
+            ".it-Footer",
+            ".it-Reactions",
+        ]

--- a/tests/test_qiita_site.py
+++ b/tests/test_qiita_site.py
@@ -1,0 +1,167 @@
+"""Tests for qiita.com site configuration."""
+
+from __future__ import annotations
+
+from md_fetch.converter import convert_to_markdown
+from md_fetch.sites import create_default_registry
+from md_fetch.sites.qiita import QiitaSiteConfig
+
+
+_CFG = QiitaSiteConfig()
+
+
+class TestQiitaSiteConfigProperties:
+    """Verify property values of QiitaSiteConfig."""
+
+    def test_name(self) -> None:
+        assert _CFG.name == "qiita"
+
+    def test_host_patterns(self) -> None:
+        assert _CFG.host_patterns == ["qiita.com", "*.qiita.com"]
+
+    def test_content_selector(self) -> None:
+        assert _CFG.content_selector == ".it-MdContent, .s-MdContent"
+
+    def test_title_selector(self) -> None:
+        assert (
+            _CFG.title_selector
+            == "h1.it-Header_title, .it-MdContent h1:first-child, article h1"
+        )
+
+    def test_remove_selectors(self) -> None:
+        assert _CFG.remove_selectors == [
+            ".it-MdContent__tableOfContents",
+            ".it-Footer",
+            ".it-Reactions",
+        ]
+
+
+class TestQiitaSiteConversion:
+    """Integration tests: qiita.com HTML -> Markdown conversion."""
+
+    def test_title_from_header(self) -> None:
+        html = (
+            '<h1 class="it-Header_title">Qiita Article Title</h1>'
+            '<div class="it-MdContent">'
+            "<p>Hello qiita</p>"
+            "</div>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert result.title == "Qiita Article Title"
+        assert "Hello qiita" in result.markdown
+
+    def test_title_from_content_h1(self) -> None:
+        html = (
+            '<div class="it-MdContent">'
+            "<h1>Content Title</h1>"
+            "<p>body text</p>"
+            "</div>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert result.title == "Content Title"
+
+    def test_title_from_article_h1(self) -> None:
+        html = (
+            "<article><h1>Article Title</h1></article>"
+            '<div class="it-MdContent">'
+            "<p>content</p>"
+            "</div>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert result.title == "Article Title"
+
+    def test_missing_title(self) -> None:
+        html = (
+            '<div class="it-MdContent">'
+            "<p>no title here</p>"
+            "</div>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert result.title == ""
+        assert "no title here" in result.markdown
+
+    def test_s_md_content_selector(self) -> None:
+        html = (
+            '<div class="s-MdContent">'
+            "<p>alternative content</p>"
+            "</div>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert "alternative content" in result.markdown
+
+    def test_remove_table_of_contents(self) -> None:
+        html = (
+            '<div class="it-MdContent">'
+            "<p>keep</p>"
+            '<div class="it-MdContent__tableOfContents">toc items</div>'
+            "</div>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert "keep" in result.markdown
+        assert "toc items" not in result.markdown
+
+    def test_remove_footer(self) -> None:
+        html = (
+            '<div class="it-MdContent">'
+            "<p>body</p>"
+            '<div class="it-Footer">footer stuff</div>'
+            "</div>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert "body" in result.markdown
+        assert "footer stuff" not in result.markdown
+
+    def test_remove_reactions(self) -> None:
+        html = (
+            '<div class="it-MdContent">'
+            "<p>text</p>"
+            '<div class="it-Reactions">likes</div>'
+            "</div>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert "text" in result.markdown
+        assert "likes" not in result.markdown
+
+    def test_full_qiita_article(self) -> None:
+        """Realistic qiita.com page structure."""
+        html = (
+            '<h1 class="it-Header_title">Python Tips</h1>'
+            '<div class="it-MdContent">'
+            '<div class="it-MdContent__tableOfContents">TOC</div>'
+            "<h2>Section 1</h2>"
+            "<p>First paragraph.</p>"
+            "<h2>Section 2</h2>"
+            "<p>Second paragraph.</p>"
+            '<div class="it-Reactions">10 likes</div>'
+            "</div>"
+            '<div class="it-Footer">footer content</div>'
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert result.title == "Python Tips"
+        assert "## Section 1" in result.markdown
+        assert "First paragraph." in result.markdown
+        assert "## Section 2" in result.markdown
+        assert "Second paragraph." in result.markdown
+        # Removed elements
+        assert "TOC" not in result.markdown
+        assert "10 likes" not in result.markdown
+        assert "footer content" not in result.markdown
+
+
+class TestDefaultRegistry:
+    """Tests for create_default_registry() with Qiita URLs."""
+
+    def test_qiita_url_matches(self) -> None:
+        registry = create_default_registry()
+        config = registry.find("https://qiita.com/user/items/abc123")
+        assert config.name == "qiita"
+
+    def test_qiita_subdomain_matches(self) -> None:
+        registry = create_default_registry()
+        config = registry.find("https://blog.qiita.com/article")
+        assert config.name == "qiita"
+
+    def test_qiita_url_with_query_params(self) -> None:
+        registry = create_default_registry()
+        config = registry.find("https://qiita.com/user/items/abc123?ref=feed")
+        assert config.name == "qiita"


### PR DESCRIPTION
## Summary
Add `QiitaSiteConfig` for qiita.com article extraction, following the same pattern as `NoteSiteConfig`. Register it in the default site registry so Qiita URLs are automatically recognized.

Closes #8

## File Context

### Files changed

**`md_fetch/sites/qiita.py`** (new file)
- Imports: `SiteConfig` from `md_fetch.sites.base`
- Follows identical property-based pattern as `NoteSiteConfig` in `md_fetch/sites/note.py`

**`md_fetch/sites/__init__.py`**
- Module-level imports (already present, NOT in diff):
  - `from fnmatch import fnmatch` (L5)
  - `from urllib.parse import urlparse` (L6)
  - `from md_fetch.sites.base import SiteConfig` (L8)
- Classes used in diff but defined in same file:
  - `SiteRegistry` (L17) — `register()` method adds configs
- Functions modified:
  - `create_default_registry()` (L57) — added `QiitaSiteConfig` import and registration

**`tests/test_qiita_site.py`** (new file)
- Imports: `convert_to_markdown` from `md_fetch.converter`, `create_default_registry` from `md_fetch.sites`, `QiitaSiteConfig` from `md_fetch.sites.qiita`
- Follows identical test structure as `tests/test_note_site.py`

## Goal / Non-Goals

**Goal:**
- Support Qiita article pages for HTML-to-Markdown conversion
- Extract article title via `h1.it-Header_title`, `.it-MdContent h1:first-child`, or `article h1`
- Extract article content via `.it-MdContent` or `.s-MdContent`
- Remove non-content elements: table of contents, footer, reactions

**Non-Goals:**
- Qiita API integration (this is HTML scraping only)
- Qiita Team (private) article support
- Dynamic content rendering (handled by existing fetcher layer)

## Data Model

N/A: No database or persistent storage involved. This is a pure configuration addition with CSS selectors.

## Existing Safety Mechanisms

- **SiteRegistry pattern matching**: `fnmatch`-based hostname matching ensures only matching URLs are routed to `QiitaSiteConfig`
- **BeautifulSoup parsing**: Content extraction uses CSS selectors; missing elements result in empty strings, not errors
- **UnsupportedSiteError**: Unknown URLs are explicitly rejected by the registry

## Code Patterns

- Site configs use `@property` methods returning static values (not class attributes)
- Each site config is a separate module under `md_fetch/sites/`
- Registry uses lazy imports inside `create_default_registry()` to avoid circular imports
- Tests follow three-class structure: Properties, Conversion (integration), Registry

## Accepted Risks

- **Qiita DOM changes may break selectors**: Qiita may update their HTML structure at any time.
  - Reason: All scraping-based tools face this inherent risk
  - Fallback: Update CSS selectors when breakage is detected; multiple selector fallbacks (`.it-MdContent, .s-MdContent`) provide some resilience

## Test Plan

- [x] `pytest tests/test_qiita_site.py -v` — 17 tests passed
  - Property values match expected selectors (5 tests)
  - Title extraction from header, content h1, article h1, and missing title (4 tests)
  - Alternative `.s-MdContent` selector works (1 test)
  - Remove selectors strip TOC, footer, reactions (3 tests)
  - Full article integration test (1 test)
  - Registry matches qiita.com, subdomain, and query-param URLs (3 tests)
- [x] `pytest tests/ -v` — no regressions (existing fetcher failures are pre-existing environment issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)