### PR TITLE
refactor(sites): minimize changes needed when adding a new site

### DIFF
--- a/hooks/site-fetch-hook.py
+++ b/hooks/site-fetch-hook.py
@@ -16,18 +16,12 @@ import sys
 import tempfile
 import urllib.request
 from pathlib import Path
-from urllib.parse import urlparse
+
+from md_fetch.sites import create_default_registry
 
 PROXY_URL = "http://127.0.0.1:19877"
-SUPPORTED_HOSTS = {"note.com", "note.mu", "qiita.com"}
 
-# Sites that need faster wait strategy (networkidle times out)
-LOAD_WAIT_HOSTS = {"qiita.com"}
-
-
-def is_supported_url(url: str) -> bool:
-    host = urlparse(url).hostname or ""
-    return any(host == h or host.endswith(f".{h}") for h in SUPPORTED_HOSTS)
+_registry = create_default_registry()
 
 
 def is_proxy_available() -> bool:
@@ -40,18 +34,10 @@ def is_proxy_available() -> bool:
         return False
 
 
-def _wait_until_for(url: str) -> str:
-    """Choose Playwright wait strategy based on host."""
-    host = urlparse(url).hostname or ""
-    if any(host == h or host.endswith(f".{h}") for h in LOAD_WAIT_HOSTS):
-        return "load"
-    return "networkidle"
-
-
 def fetch_html(url: str, timeout_ms: int = 30_000) -> str:
     """Fetch rendered HTML from playwright proxy."""
-    wait_until = _wait_until_for(url)
-    payload = json.dumps({"url": url, "timeout_ms": timeout_ms, "wait_until": wait_until}).encode()
+    site = _registry.find(url)
+    payload = json.dumps({"url": url, "timeout_ms": timeout_ms, "wait_until": site.wait_until}).encode()
     req = urllib.request.Request(
         PROXY_URL,
         data=payload,
@@ -72,10 +58,8 @@ def convert_to_md(html: str, url: str) -> tuple[str, str, str]:
     Returns (markdown_with_title, title, site_name).
     """
     from md_fetch.converter import convert_to_markdown
-    from md_fetch.sites import create_default_registry
 
-    registry = create_default_registry()
-    site = registry.find(url)
+    site = _registry.find(url)
     result = convert_to_markdown(html, site)
     title = result.title or ""
     md = f"# {title}\n\n{result.markdown}" if title else result.markdown
@@ -104,7 +88,7 @@ def main():
         sys.exit(0)
 
     url = data.get("tool_input", {}).get("url", "")
-    if not is_supported_url(url):
+    if not _registry.is_supported(url):
         sys.exit(0)
 
     if not is_proxy_available():

--- a/md_fetch/cli.py
+++ b/md_fetch/cli.py
@@ -132,7 +132,7 @@ def _run(argv: list[str] | None = None) -> int:
         return 1
 
     try:
-        html = fetch_page(args.url)
+        html = fetch_page(args.url, wait_until=site_config.wait_until)
     except FetchError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1

--- a/md_fetch/fetcher.py
+++ b/md_fetch/fetcher.py
@@ -59,9 +59,9 @@ def _is_proxy_available() -> bool:
         return False
 
 
-def _fetch_via_proxy(url: str, *, timeout_ms: int) -> str:
+def _fetch_via_proxy(url: str, *, timeout_ms: int, wait_until: str = "networkidle") -> str:
     """Fetch a URL via the playwright-http-server proxy."""
-    payload = json.dumps({"url": url, "timeout_ms": timeout_ms}).encode()
+    payload = json.dumps({"url": url, "timeout_ms": timeout_ms, "wait_until": wait_until}).encode()
     req = urllib.request.Request(
         _PROXY_URL,
         data=payload,
@@ -82,16 +82,14 @@ def _fetch_via_proxy(url: str, *, timeout_ms: int) -> str:
     return data["html"]
 
 
-def _fetch_via_playwright(url: str, *, timeout_ms: int) -> str:
+def _fetch_via_playwright(url: str, *, timeout_ms: int, wait_until: str = "networkidle") -> str:
     """Fetch a URL directly using Playwright."""
     try:
         with sync_playwright() as pw:
             browser = pw.chromium.launch(headless=True)
             try:
                 page = browser.new_page()
-                # networkidle waits for no network connections for 500ms,
-                # which is the best heuristic for JS-rendered article pages.
-                page.goto(url, wait_until="networkidle", timeout=timeout_ms)
+                page.goto(url, wait_until=wait_until, timeout=timeout_ms)
                 return page.content()
             except PlaywrightError as exc:
                 raise _convert_playwright_error(exc) from exc
@@ -102,7 +100,12 @@ def _fetch_via_playwright(url: str, *, timeout_ms: int) -> str:
         raise _convert_playwright_error(exc) from exc
 
 
-def fetch_page(url: str, *, timeout_ms: int = _DEFAULT_TIMEOUT_MS) -> str:
+def fetch_page(
+    url: str,
+    *,
+    timeout_ms: int = _DEFAULT_TIMEOUT_MS,
+    wait_until: str = "networkidle",
+) -> str:
     """Fetch a URL and return the fully-rendered HTML.
 
     Tries the playwright-http-server proxy first. If the proxy is not
@@ -111,6 +114,7 @@ def fetch_page(url: str, *, timeout_ms: int = _DEFAULT_TIMEOUT_MS) -> str:
     Args:
         url: The URL to fetch.
         timeout_ms: Navigation timeout in milliseconds.
+        wait_until: Playwright wait strategy (e.g. "networkidle", "load").
 
     Returns:
         The rendered HTML as a string.
@@ -121,5 +125,5 @@ def fetch_page(url: str, *, timeout_ms: int = _DEFAULT_TIMEOUT_MS) -> str:
         FetchError: Any other Playwright error.
     """
     if _is_proxy_available():
-        return _fetch_via_proxy(url, timeout_ms=timeout_ms)
-    return _fetch_via_playwright(url, timeout_ms=timeout_ms)
+        return _fetch_via_proxy(url, timeout_ms=timeout_ms, wait_until=wait_until)
+    return _fetch_via_playwright(url, timeout_ms=timeout_ms, wait_until=wait_until)

--- a/md_fetch/sites/__init__.py
+++ b/md_fetch/sites/__init__.py
@@ -53,6 +53,17 @@ class SiteRegistry:
             f"No site configuration found for host {host!r}"
         )
 
+    def find_or_none(self, url: str) -> SiteConfig | None:
+        """Find the matching SiteConfig, or return None on any failure."""
+        try:
+            return self.find(url)
+        except (ValueError, UnsupportedSiteError):
+            return None
+
+    def is_supported(self, url: str) -> bool:
+        """Return True if *url* matches any registered site."""
+        return self.find_or_none(url) is not None
+
 
 def create_default_registry() -> SiteRegistry:
     """Create a SiteRegistry pre-loaded with all built-in site configurations."""

--- a/md_fetch/sites/base.py
+++ b/md_fetch/sites/base.py
@@ -27,3 +27,8 @@ class SiteConfig(ABC):
     @property
     @abstractmethod
     def remove_selectors(self) -> list[str]: ...
+
+    @property
+    def wait_until(self) -> str:
+        """Playwright wait strategy. Override per site if needed."""
+        return "networkidle"

--- a/md_fetch/sites/note.py
+++ b/md_fetch/sites/note.py
@@ -14,7 +14,7 @@ class NoteSiteConfig(SiteConfig):
 
     @property
     def host_patterns(self) -> list[str]:
-        return ["note.com", "*.note.com"]
+        return ["note.com", "*.note.com", "note.mu", "*.note.mu"]
 
     @property
     def content_selector(self) -> str:

--- a/md_fetch/sites/qiita.py
+++ b/md_fetch/sites/qiita.py
@@ -31,3 +31,7 @@ class QiitaSiteConfig(SiteConfig):
             ".it-Footer",
             ".it-Reactions",
         ]
+
+    @property
+    def wait_until(self) -> str:
+        return "load"

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -189,7 +189,7 @@ class TestFetchPageFallback:
 
         assert result == "<html>proxy</html>"
         mock_proxy.assert_called_once_with(
-            "https://example.com", timeout_ms=30_000,
+            "https://example.com", timeout_ms=30_000, wait_until="networkidle",
         )
 
     @patch("md_fetch.fetcher._fetch_via_playwright")
@@ -203,7 +203,7 @@ class TestFetchPageFallback:
 
         assert result == "<html>direct</html>"
         mock_pw.assert_called_once_with(
-            "https://example.com", timeout_ms=30_000,
+            "https://example.com", timeout_ms=30_000, wait_until="networkidle",
         )
 
     @patch("md_fetch.fetcher._fetch_via_playwright")
@@ -228,5 +228,16 @@ class TestFetchPageFallback:
         fetch_page("https://example.com", timeout_ms=5_000)
 
         mock_proxy.assert_called_once_with(
-            "https://example.com", timeout_ms=5_000,
+            "https://example.com", timeout_ms=5_000, wait_until="networkidle",
+        )
+
+    @patch("md_fetch.fetcher._fetch_via_proxy")
+    @patch("md_fetch.fetcher._is_proxy_available", return_value=True)
+    def test_passes_custom_wait_until(self, mock_avail, mock_proxy):
+        mock_proxy.return_value = "<html>ok</html>"
+
+        fetch_page("https://example.com", wait_until="load")
+
+        mock_proxy.assert_called_once_with(
+            "https://example.com", timeout_ms=30_000, wait_until="load",
         )

--- a/tests/test_note_site.py
+++ b/tests/test_note_site.py
@@ -19,7 +19,10 @@ class TestNoteSiteConfigProperties:
         assert _CFG.name == "note"
 
     def test_host_patterns(self) -> None:
-        assert _CFG.host_patterns == ["note.com", "*.note.com"]
+        assert _CFG.host_patterns == ["note.com", "*.note.com", "note.mu", "*.note.mu"]
+
+    def test_wait_until(self) -> None:
+        assert _CFG.wait_until == "networkidle"
 
     def test_content_selector(self) -> None:
         assert _CFG.content_selector == ".note-common-styles__textnote-body"
@@ -138,6 +141,16 @@ class TestDefaultRegistry:
     def test_note_subdomain_matches(self) -> None:
         registry = create_default_registry()
         config = registry.find("https://www.note.com/article")
+        assert config.name == "note"
+
+    def test_note_mu_matches(self) -> None:
+        registry = create_default_registry()
+        config = registry.find("https://note.mu/user/n/abc123")
+        assert config.name == "note"
+
+    def test_note_mu_subdomain_matches(self) -> None:
+        registry = create_default_registry()
+        config = registry.find("https://www.note.mu/article")
         assert config.name == "note"
 
     def test_unknown_site_raises(self) -> None:

--- a/tests/test_qiita_site.py
+++ b/tests/test_qiita_site.py
@@ -35,6 +35,9 @@ class TestQiitaSiteConfigProperties:
             ".it-Reactions",
         ]
 
+    def test_wait_until(self) -> None:
+        assert _CFG.wait_until == "load"
+
 
 class TestQiitaSiteConversion:
     """Integration tests: qiita.com HTML -> Markdown conversion."""

--- a/tests/test_sites.py
+++ b/tests/test_sites.py
@@ -121,3 +121,45 @@ class TestSiteRegistryBoundary:
     def test_abc_cannot_be_instantiated(self) -> None:
         with pytest.raises(TypeError):
             SiteConfig()  # type: ignore[abstract]
+
+
+class TestWaitUntilDefault:
+    """Default wait_until property."""
+
+    def test_default_is_networkidle(self) -> None:
+        config = _DummySiteConfig()
+        assert config.wait_until == "networkidle"
+
+
+class TestFindOrNone:
+    """SiteRegistry.find_or_none behaviour."""
+
+    def test_returns_config_for_known_host(self, registry: SiteRegistry) -> None:
+        config = registry.find_or_none("https://note.com/article")
+        assert config is not None
+        assert config.name == "dummy"
+
+    def test_returns_none_for_unknown_host(self, registry: SiteRegistry) -> None:
+        assert registry.find_or_none("https://example.com/page") is None
+
+    def test_returns_none_for_empty_url(self, registry: SiteRegistry) -> None:
+        assert registry.find_or_none("") is None
+
+    def test_returns_none_for_invalid_url(self, registry: SiteRegistry) -> None:
+        assert registry.find_or_none("not-a-url") is None
+
+
+class TestIsSupported:
+    """SiteRegistry.is_supported behaviour."""
+
+    def test_true_for_known_host(self, registry: SiteRegistry) -> None:
+        assert registry.is_supported("https://note.com/article") is True
+
+    def test_false_for_unknown_host(self, registry: SiteRegistry) -> None:
+        assert registry.is_supported("https://example.com/page") is False
+
+    def test_false_for_empty_url(self, registry: SiteRegistry) -> None:
+        assert registry.is_supported("") is False
+
+    def test_false_for_invalid_url(self, registry: SiteRegistry) -> None:
+        assert registry.is_supported("not-a-url") is False


### PR DESCRIPTION
## Summary
- SiteConfig に wait_until プロパティを追加し、hook の SUPPORTED_HOSTS / LOAD_WAIT_HOSTS をレジストリに統合
- 新サイト追加時の変更箇所を **3箇所 → 2箇所** に削減（sites/newsite.py + sites/__init__.py のみ）
- NoteSiteConfig に note.mu パターンを追加（hook との不整合を修正）

### 変更内容
| ファイル | 変更 |
|---------|------|
| md_fetch/sites/base.py | wait_until プロパティ追加 (default: networkidle) |
| md_fetch/sites/qiita.py | wait_until を load にオーバーライド |
| md_fetch/sites/note.py | host_patterns に note.mu, *.note.mu 追加 |
| md_fetch/sites/__init__.py | find_or_none, is_supported メソッド追加 |
| md_fetch/fetcher.py | wait_until パラメータ追加（後方互換） |
| md_fetch/cli.py | site_config.wait_until を fetch_page に渡す |
| hooks/site-fetch-hook.py | SUPPORTED_HOSTS/LOAD_WAIT_HOSTS 削除、レジストリに統合 |

## Test plan
- [x] pytest tests/ -v — 新規テスト含め78件パス
- [x] hook 単体テスト: note.com, note.mu, qiita.com → サポート認識、example.com → スキップ

Closes #17

Generated with [Claude Code](https://claude.com/claude-code)