### PR TITLE
feat(sites): add Zenn (zenn.dev) site support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ gh md-fetch https://note.com/user/n/xxxxxxxxxx -o ./output
 |------|-------------|
 | note | `note.com`, `*.note.com` |
 | Qiita | `qiita.com`, `*.qiita.com` |
+| Zenn | `zenn.dev` |
 
 ## Claude Code integration
 
@@ -77,7 +78,7 @@ verbose モード:
 
 #### 2. Configure Claude Code hook (optional)
 
-Claude Code が `WebFetch` で note.com / qiita.com URL にアクセスした際、自動的にプロキシ経由で取得するための hook。
+Claude Code が `WebFetch` で note.com / qiita.com / zenn.dev URL にアクセスした際、自動的にプロキシ経由で取得するための hook。
 記事は temp ファイルに保存され、`additionalContext` でファイルパスが Claude に通知される。
 
 `.claude/settings.local.json` に追加:
@@ -162,6 +163,7 @@ gh-md-fetch
 │       ├── base.py      # SiteConfig ABC
 │       ├── note.py      # note.com config
 │       ├── qiita.py     # qiita.com config
+│       ├── zenn.py      # zenn.dev config
 │       └── __init__.py  # SiteRegistry
 ├── hooks/
 │   ├── playwright-http-server.py  # Proxy server for sandbox bypass

--- a/hooks/site-fetch-hook.py
+++ b/hooks/site-fetch-hook.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""PreToolUse hook: fetch note.com / qiita.com articles via playwright proxy.
+"""PreToolUse hook: fetch note.com / qiita.com / zenn.dev articles via playwright proxy.
 
 Intercepts WebFetch for supported sites, fetches rendered HTML through
 playwright-http-server, converts to markdown via md_fetch pipeline,
@@ -19,10 +19,10 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 PROXY_URL = "http://127.0.0.1:19877"
-SUPPORTED_HOSTS = {"note.com", "note.mu", "qiita.com"}
+SUPPORTED_HOSTS = {"note.com", "note.mu", "qiita.com", "zenn.dev"}
 
 # Sites that need faster wait strategy (networkidle times out)
-LOAD_WAIT_HOSTS = {"qiita.com"}
+LOAD_WAIT_HOSTS = {"qiita.com", "zenn.dev"}
 
 
 def is_supported_url(url: str) -> bool:

--- a/md_fetch/sites/__init__.py
+++ b/md_fetch/sites/__init__.py
@@ -58,8 +58,10 @@ def create_default_registry() -> SiteRegistry:
     """Create a SiteRegistry pre-loaded with all built-in site configurations."""
     from md_fetch.sites.note import NoteSiteConfig
     from md_fetch.sites.qiita import QiitaSiteConfig
+    from md_fetch.sites.zenn import ZennSiteConfig
 
     registry = SiteRegistry()
     registry.register(NoteSiteConfig())
     registry.register(QiitaSiteConfig())
+    registry.register(ZennSiteConfig())
     return registry

--- a/md_fetch/sites/zenn.py
+++ b/md_fetch/sites/zenn.py
@@ -1,0 +1,38 @@
+"""Site configuration for zenn.dev."""
+
+from __future__ import annotations
+
+from md_fetch.sites.base import SiteConfig
+
+
+class ZennSiteConfig(SiteConfig):
+    """Extraction configuration for zenn.dev articles."""
+
+    @property
+    def name(self) -> str:
+        return "zenn"
+
+    @property
+    def host_patterns(self) -> list[str]:
+        return ["zenn.dev"]
+
+    @property
+    def content_selector(self) -> str:
+        return "div.znc"
+
+    @property
+    def title_selector(self) -> str:
+        return 'h1[class*="ArticleHeader_title"], article h1, h1'
+
+    @property
+    def remove_selectors(self) -> list[str]:
+        return [
+            'div[class*="ArticleComments"]',
+            'aside[class*="View_sidebarContainer"]',
+            'div[class*="ArticleSidebar"]',
+            'div[class*="ProfileCard"]',
+            "a.header-anchor-link",
+            'button[class*="copyButton"]',
+            'button[class*="wrapButton"]',
+            'button[class*="FollowButton"]',
+        ]

--- a/tests/test_zenn_site.py
+++ b/tests/test_zenn_site.py
@@ -1,0 +1,206 @@
+"""Tests for zenn.dev site configuration."""
+
+from __future__ import annotations
+
+from md_fetch.converter import convert_to_markdown
+from md_fetch.sites import create_default_registry
+from md_fetch.sites.zenn import ZennSiteConfig
+
+
+_CFG = ZennSiteConfig()
+
+
+class TestZennSiteConfigProperties:
+    """Verify property values of ZennSiteConfig."""
+
+    def test_name(self) -> None:
+        assert _CFG.name == "zenn"
+
+    def test_host_patterns(self) -> None:
+        assert _CFG.host_patterns == ["zenn.dev"]
+
+    def test_content_selector(self) -> None:
+        assert _CFG.content_selector == "div.znc"
+
+    def test_title_selector(self) -> None:
+        assert (
+            _CFG.title_selector
+            == 'h1[class*="ArticleHeader_title"], article h1, h1'
+        )
+
+    def test_remove_selectors(self) -> None:
+        assert _CFG.remove_selectors == [
+            'div[class*="ArticleComments"]',
+            'aside[class*="View_sidebarContainer"]',
+            'div[class*="ArticleSidebar"]',
+            'div[class*="ProfileCard"]',
+            "a.header-anchor-link",
+            'button[class*="copyButton"]',
+            'button[class*="wrapButton"]',
+            'button[class*="FollowButton"]',
+        ]
+
+
+class TestZennSiteConversion:
+    """Integration tests: zenn.dev HTML -> Markdown conversion."""
+
+    def test_title_from_css_modules_class(self) -> None:
+        """Title extraction via [class*=ArticleHeader_title] partial match."""
+        html = (
+            '<h1 class="ArticleHeader_title__ab12c">Zenn Article Title</h1>'
+            '<div class="znc">'
+            "<p>Hello zenn</p>"
+            "</div>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert result.title == "Zenn Article Title"
+        assert "Hello zenn" in result.markdown
+
+    def test_title_from_article_h1(self) -> None:
+        """Fallback: article h1."""
+        html = (
+            "<article><h1>Article Fallback Title</h1></article>"
+            '<div class="znc">'
+            "<p>content</p>"
+            "</div>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert result.title == "Article Fallback Title"
+
+    def test_title_from_bare_h1(self) -> None:
+        """Fallback: bare h1."""
+        html = (
+            "<h1>Bare Title</h1>"
+            '<div class="znc">'
+            "<p>content</p>"
+            "</div>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert result.title == "Bare Title"
+
+    def test_missing_title(self) -> None:
+        html = (
+            '<div class="znc">'
+            "<p>no title here</p>"
+            "</div>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert result.title == ""
+        assert "no title here" in result.markdown
+
+    def test_remove_copy_button(self) -> None:
+        html = (
+            '<div class="znc">'
+            "<p>keep</p>"
+            '<button class="copyButton__x9f2a">Copy</button>'
+            "</div>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert "keep" in result.markdown
+        assert "Copy" not in result.markdown
+
+    def test_remove_comments(self) -> None:
+        html = (
+            '<div class="znc">'
+            "<p>article body</p>"
+            '<div class="ArticleComments__abc12">comments here</div>'
+            "</div>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert "article body" in result.markdown
+        assert "comments here" not in result.markdown
+
+    def test_remove_sidebar(self) -> None:
+        html = (
+            '<aside class="View_sidebarContainer__xyz">'
+            "<p>sidebar</p>"
+            "</aside>"
+            '<div class="znc">'
+            "<p>main content</p>"
+            "</div>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert "main content" in result.markdown
+        assert "sidebar" not in result.markdown
+
+    def test_remove_follow_button(self) -> None:
+        html = (
+            '<div class="znc">'
+            "<p>text</p>"
+            '<button class="FollowButton__abc">Follow</button>'
+            "</div>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert "text" in result.markdown
+        assert "Follow" not in result.markdown
+
+    def test_remove_wrap_button(self) -> None:
+        html = (
+            '<div class="znc">'
+            "<p>code block</p>"
+            '<button class="wrapButton__def">Wrap</button>'
+            "</div>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert "code block" in result.markdown
+        assert "Wrap" not in result.markdown
+
+    def test_remove_anchor_link(self) -> None:
+        html = (
+            '<div class="znc">'
+            "<h2>Section</h2>"
+            '<a class="header-anchor-link">#</a>'
+            "<p>content</p>"
+            "</div>"
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert "Section" in result.markdown
+        assert "#" not in result.markdown or "##" in result.markdown
+
+    def test_full_zenn_article(self) -> None:
+        """Realistic zenn.dev page structure with CSS Modules hashed classes."""
+        html = (
+            '<h1 class="ArticleHeader_title__a1b2c">Zenn Tips</h1>'
+            '<aside class="View_sidebarContainer__x9y8z">'
+            '<div class="ProfileCard__p1q2r">Author info</div>'
+            "</aside>"
+            '<div class="znc">'
+            "<h2>Section 1</h2>"
+            '<a class="header-anchor-link">#</a>'
+            "<p>First paragraph.</p>"
+            '<button class="copyButton__c3d4e">Copy</button>'
+            "<h2>Section 2</h2>"
+            "<p>Second paragraph.</p>"
+            '<button class="wrapButton__f5g6h">Wrap</button>'
+            '<div class="ArticleComments__i7j8k">User comments</div>'
+            '<button class="FollowButton__l9m0n">Follow</button>'
+            "</div>"
+            '<div class="ArticleSidebar__o1p2q">Related articles</div>'
+        )
+        result = convert_to_markdown(html, _CFG)
+        assert result.title == "Zenn Tips"
+        assert "## Section 1" in result.markdown
+        assert "First paragraph." in result.markdown
+        assert "## Section 2" in result.markdown
+        assert "Second paragraph." in result.markdown
+        # Removed elements
+        assert "Author info" not in result.markdown
+        assert "Copy" not in result.markdown
+        assert "Wrap" not in result.markdown
+        assert "User comments" not in result.markdown
+        assert "Follow" not in result.markdown
+        assert "Related articles" not in result.markdown
+
+
+class TestDefaultRegistry:
+    """Tests for create_default_registry() with Zenn URLs."""
+
+    def test_zenn_url_matches(self) -> None:
+        registry = create_default_registry()
+        config = registry.find("https://zenn.dev/and_and/articles/8e4dc3a47e7873")
+        assert config.name == "zenn"
+
+    def test_zenn_url_with_query_params(self) -> None:
+        registry = create_default_registry()
+        config = registry.find("https://zenn.dev/user/articles/abc123?ref=feed")
+        assert config.name == "zenn"


### PR DESCRIPTION
## Summary

Zenn (zenn.dev) の記事を Markdown 変換できるサイト対応を追加。
CSS Modules 部分一致セレクタ (`[class*=...]`) で Next.js ベースのクラス名に対応し、
`div.znc` をコンテンツセレクタに使用（CSS Modules 非依存の安定クラス）。

Closes #21

## File Context

### Files changed

**`md_fetch/sites/zenn.py`** (新規)
- Imports: `SiteConfig` from `md_fetch.sites.base` (ABC)
- `ZennSiteConfig` class — all properties via `@property` decorator (existing pattern from `qiita.py`)

**`md_fetch/sites/__init__.py`**
- Existing imports: `NoteSiteConfig` (L59), `QiitaSiteConfig` (L60)
- Existing function: `create_default_registry()` (L57) — factory for `SiteRegistry`
- Added: `ZennSiteConfig` import and `registry.register(ZennSiteConfig())`

**`hooks/site-fetch-hook.py`**
- Module-level constants used in diff: `SUPPORTED_HOSTS` (L22), `LOAD_WAIT_HOSTS` (L25)
- Added `zenn.dev` to both sets

**`tests/test_zenn_site.py`** (新規)
- Imports: `convert_to_markdown` from `md_fetch.converter`, `create_default_registry` from `md_fetch.sites`, `ZennSiteConfig` from `md_fetch.sites.zenn`
- 3 test classes, 18 test methods total

**`README.md`**
- Supported sites table, hook description, project structure updated

## Goal / Non-Goals

**Goal:**
- zenn.dev 記事の Markdown 変換サポート
- CSS Modules ハッシュ付きクラス名への部分一致セレクタ対応
- hook (`site-fetch-hook.py`) での自動フェッチ対応

**Non-Goals:**
- Zenn Books (`zenn.dev/books/...`) 対応 — 記事のみスコープ
- Zenn Scraps 対応
- サブドメイン対応（zenn.dev はサブドメイン未使用）

## Data Model

N/A: DB 操作なし。`SiteConfig` プロパティのみ（純粋な設定値）。

## Existing Safety Mechanisms

- **SiteRegistry pattern matching**: `fnmatch` による hostname パターンマッチ。未対応 URL は `UnsupportedSiteError` で fail-fast
- **remove_selectors による不要要素除去**: `convert_to_markdown()` が BeautifulSoup で対象要素を削除してから markdownify に渡す
- **LOAD_WAIT_HOSTS**: Next.js SPA の networkidle タイムアウトを回避するため `load` wait strategy を使用

## Code Patterns

- サイト設定は `SiteConfig` ABC を継承し、全プロパティを `@property` で定義（`qiita.py` / `note.py` と同一パターン）
- テスト構造: `TestXxxSiteConfigProperties` + `TestXxxSiteConversion` + `TestDefaultRegistry` の3クラス構成
- `create_default_registry()` で lazy import + register

## Accepted Risks

- **CSS Modules クラス名変更リスク**: Zenn のデプロイでハッシュサフィックスが変わる可能性
  - Reason: `[class*=...]` 部分一致セレクタで prefix 部分のみマッチするため、ハッシュ変更の影響を受けない
  - Fallback: `div.znc` は CSS Modules 非依存の安定クラスのため、content_selector は影響なし。title/remove は部分一致で吸収
- **`div.znc` がコメント本文にも使われる**: 記事本文とコメント本文の両方に `div.znc` が存在
  - Reason: `ArticleComments` を remove_selectors で除外することで記事本文のみ残る
  - Fallback: コメントが残った場合でもコンテンツとしては有害ではない

## Test Plan

- [x] `pytest tests/test_zenn_site.py -v` — 18/18 passed
- [x] `pytest tests/ -v --ignore=tests/test_fetcher.py` — Zenn 関連テスト全 PASS、既存テストにリグレッションなし
- [ ] E2E: `https://zenn.dev/and_and/articles/8e4dc3a47e7873` (playwright-http-server 起動時)

🤖 Generated with [Claude Code](https://claude.com/claude-code)